### PR TITLE
Implement silent mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,7 @@ CLI app and package that uses google spreadsheet api to export calendar data dir
 
 ## Planned releases
 
-- Full cli support (75%)
 - Web application (Working on)
-- Publish to npm package registry (Working on)
 - Publish to homebrew
 
 ## Supported exports
@@ -50,15 +48,18 @@ CLI app and package that uses google spreadsheet api to export calendar data dir
 $ gsToCalendar
 ```
 
-| Argument          | Description                                                                                                   | Defaults      |
-| ----------------- | ------------------------------------------------------------------------------------------------------------- | ------------- |
-| docId             | Defines the google document id                                                                                | null          |
-| sheetId           | Defines the google sheet id                                                                                   | null          |
-| dateFormat        | Defines the date string format.Follow [date-fns parse documentation](https://date-fns.org/v2.29.3/docs/parse) | "d 'de' MMMM" |
-| dateStringColumn  | Defines wich column contains the date string                                                                  | null          |
-| titleStringColumn | Defines wich column contains the event title string                                                           | null          |
-| locale            | Defines the locale for the date-fns. (ISO 639-1)                                                              | ptBR          |
-| startColumn       | Define the initial column                                                                                     | A             |
+| Props                     | Description                                                                                                   | Required | Default       |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------- | -------- | ------------- |
+| sheetId                   | Google sheet id from current document                                                                         | false    | null          |
+| options                   | Options object                                                                                                | false    | null          |
+| options.debug             | Enable error logging                                                                                          | false    | false         |
+| options.docId             | Defines the google document id                                                                                | false    | null          |
+| options.sheetId           | Defines the google sheet id                                                                                   | false    | null          |
+| options.dateFormat        | Defines the date string format.Follow [date-fns parse documentation](https://date-fns.org/v2.29.3/docs/parse) | false    | "d 'de' MMMM" |
+| options.dateStringColumn  | Defines wich column contains the date string                                                                  | false    | null          |
+| options.titleStringColumn | Defines wich column contains the event title string                                                           | false    | null          |
+| options.locale            | Defines the locale for the date-fns. (ISO 639-1)                                                              | false    | ptBR          |
+| options.startColumn       | Define the initial column                                                                                     | false    | A             |
 
 ## Usage as a package
 

--- a/src/actions/init.ts
+++ b/src/actions/init.ts
@@ -1,12 +1,12 @@
 import _export, { exportMethods } from '../export';
-import cliSpinners from 'cli-spinners';
-import ora from 'ora';
 import fetchEvents from './fetchEvents/fetchEvents';
 import Enquirer from 'enquirer';
 import googleSheet from './googleSheet';
 import { CLIArguments } from '../cli';
 import { LocaleKeyTypes } from './fetchEvents/fetchEvents.types';
 import prompts from './prompts';
+import { isSilent } from '../utils';
+import { useSpinner } from '../utils/spinner/spinner';
 
 const fetchSheetInformation = async (args?: {
   docId?: string;
@@ -14,16 +14,14 @@ const fetchSheetInformation = async (args?: {
 }) => {
   const docId = args?.docId ? args.docId : (await prompts.getDocInfo()).docId;
 
-  const spinner = ora({
-    text: 'Trying to fetch spreadsheet...',
-    spinner: cliSpinners.dots
-  });
-  spinner.start();
+  const spinner = useSpinner('Trying to fetch spreadsheet...');
+  if (!isSilent) spinner.start();
 
   const document = await googleSheet.loadDocument(docId, (msg) => {
     spinner.text = msg;
     spinner.fail();
   });
+
   spinner.text = `Succesfully loaded ${document.title}`;
   spinner.succeed();
 
@@ -45,11 +43,9 @@ export default async (args: CLIArguments) => {
     sheetId: args.sheetId
   }).catch(() => process.exit(1));
 
-  const spinner = ora({
-    text: 'Trying to fetch calendar...',
-    spinner: cliSpinners.dots
-  });
-  spinner.start();
+  const spinner = useSpinner('Trying to fetch calendar...');
+
+  if (!isSilent) spinner.start();
 
   const locale = `${args.locale.split('-')[0]}${
     args.locale.split('-')[1] ? args.locale.split('-')[1].toUpperCase() : ''

--- a/src/actions/init.ts
+++ b/src/actions/init.ts
@@ -1,12 +1,12 @@
 import _export, { exportMethods } from '../export';
 import fetchEvents from './fetchEvents/fetchEvents';
-import Enquirer from 'enquirer';
 import googleSheet from './googleSheet';
 import { CLIArguments } from '../cli';
 import { LocaleKeyTypes } from './fetchEvents/fetchEvents.types';
 import prompts from './prompts';
 import { isSilent } from '../utils';
 import { useSpinner } from '../utils/spinner/spinner';
+import { exportPrompt } from './prompts/export';
 
 const fetchSheetInformation = async (args?: {
   docId?: string;
@@ -76,18 +76,12 @@ export default async (args: CLIArguments) => {
 
   spinner.stop();
 
-  const select = await new Enquirer<{ values?: keyof typeof _export }>()
-    .prompt({
-      type: 'select',
-      name: 'values',
-      message: 'Select an export method',
-      choices: exportMethods
-    })
-    .catch(() => ({ values: undefined }));
+  const exportMethod =
+    (args.exportAs as keyof typeof _export) || (await exportPrompt()).export;
 
   const { calendarTitle, events } = res;
 
-  if (!select.values) process.exit(1);
+  if (!exportMethods.includes(exportMethod)) process.exit(1);
 
-  _export[select.values](calendarTitle, events, locale);
+  _export[exportMethod](calendarTitle, events, locale);
 };

--- a/src/actions/prompts/export.ts
+++ b/src/actions/prompts/export.ts
@@ -1,0 +1,17 @@
+import Enquirer from 'enquirer';
+import _export, { exportMethods } from '../../export';
+
+export const exportPrompt = async () => {
+  const select = await new Enquirer<{
+    export?: keyof typeof _export;
+  }>()
+    .prompt({
+      type: 'select',
+      name: 'export',
+      message: 'Select an export method',
+      choices: exportMethods
+    })
+    .catch(() => ({ export: undefined }));
+
+  return select;
+};

--- a/src/export/google/index.ts
+++ b/src/export/google/index.ts
@@ -1,9 +1,8 @@
 import { oauth2 } from '@googleapis/oauth2';
 import chalk from 'chalk';
-import cliSpinners from 'cli-spinners';
 import Enquirer from 'enquirer';
-import ora from 'ora';
-import { log } from '../../utils';
+import { isSilent, log } from '../../utils';
+import { useSpinner } from '../../utils/spinner/spinner';
 import { generateCalendar } from './generateCalendar';
 import { getOAuthClient } from './getOAuthClient';
 import { handleLogin } from './handleLogin';
@@ -39,11 +38,9 @@ export default async (
   });
 
   if (option === 'oAuth') {
-    const spinner = ora({
-      text: 'Waiting for google...',
-      spinner: cliSpinners.dots
-    });
-    spinner.start();
+    const spinner = useSpinner('Waiting for google...');
+
+    if (!isSilent) spinner.start();
 
     setTimeout(() => {
       spinner.text = 'Timed out';

--- a/src/export/ics/createIcsFile.ts
+++ b/src/export/ics/createIcsFile.ts
@@ -1,12 +1,11 @@
 import chalk from 'chalk';
-import cliSpinners from 'cli-spinners';
 import { addDays, format } from 'date-fns';
 import fs from 'fs';
 import * as ics from 'ics';
-import ora from 'ora';
 import path from 'path';
-import { log } from '../../utils';
+import { isSilent, log } from '../../utils';
 import Enquirer from 'enquirer';
+import { useSpinner } from '../../utils/spinner/spinner';
 
 export default async (calendarTitle: string, events: EventTypes[]) => {
   const qa = new Enquirer<{ saveUrl: string }>();
@@ -22,11 +21,10 @@ export default async (calendarTitle: string, events: EventTypes[]) => {
     saveUrl || ''
   )}/${calendarTitle}.ics`;
 
-  const spinner = ora({
-    text: `Writing file to ${writePath}`,
-    spinner: cliSpinners.dots
-  });
-  spinner.start();
+  const spinner = useSpinner(`Writing file to ${writePath}`);
+
+  if (!isSilent) spinner.start();
+
   const parsedEvents = events.map(
     (event) =>
       ({

--- a/src/utils/logger/index.ts
+++ b/src/utils/logger/index.ts
@@ -6,15 +6,35 @@ type TFunction = ((chalk: Chalk) => string) | string;
 const renderText = (text: string | TFunction) =>
   typeof text === 'string' ? text : text(chalk);
 
-export const log = {
-  error: (text: TFunction) =>
-    Log(
-      `${chalk.bold.bgRed(`| ERROR |`)}${chalk.gray(` ${renderText(text)}`)}`
-    ),
-  info: (text: TFunction) =>
-    Log(
-      `${chalk.bold.bgCyan(`| INFO |`)}${chalk.gray(` ${renderText(text)}`)}`
-    ),
-  text: (text: TFunction) =>
-    Log(`${chalk.bold.bgCyan(`| INFO |`)}${chalk.gray(` ${renderText(text)}`)}`)
+export const isSilent =
+  process.argv.find((where) => where === '--s' || where === '--silent') !==
+  undefined;
+
+const silentObject = {
+  error: () => null,
+  info: () => null,
+  text: () => null
 };
+
+export const log = isSilent
+  ? silentObject
+  : {
+      error: (text: TFunction) =>
+        Log(
+          `${chalk.bold.bgRed(`| ERROR |`)}${chalk.gray(
+            ` ${renderText(text)}`
+          )}`
+        ),
+      info: (text: TFunction) =>
+        Log(
+          `${chalk.bold.bgCyan(`| INFO |`)}${chalk.gray(
+            ` ${renderText(text)}`
+          )}`
+        ),
+      text: (text: TFunction) =>
+        Log(
+          `${chalk.bold.bgCyan(`| INFO |`)}${chalk.gray(
+            ` ${renderText(text)}`
+          )}`
+        )
+    };

--- a/src/utils/spinner/spinner.ts
+++ b/src/utils/spinner/spinner.ts
@@ -1,0 +1,14 @@
+import cliSpinners from 'cli-spinners';
+import ora from 'ora';
+import { isSilent } from '../logger';
+
+export const useSpinner = (initialText: string) => {
+  const oraInstance = ora({
+    text: initialText,
+    spinner: cliSpinners.dots,
+    isEnabled: !isSilent,
+    isSilent
+  });
+
+  return oraInstance;
+};


### PR DESCRIPTION
The `--silent` flag runs a command without producing any output on the console. It is being used in conjunction with the required `--docId` and `--exportAs` options to export a document.